### PR TITLE
Track changes in GHC v7.7 and up

### DIFF
--- a/Data/Sized/Fin.hs
+++ b/Data/Sized/Fin.hs
@@ -7,7 +7,10 @@
 -- Stability: unstable
 -- Portability: ghc
 {-# LANGUAGE TypeFamilies, ScopedTypeVariables, UndecidableInstances, FlexibleInstances, GADTs, DeriveDataTypeable  #-}
-{-# LANGUAGE DataKinds, KindSignatures, TypeOperators #-}
+{-# LANGUAGE CPP, DataKinds, KindSignatures, TypeOperators #-}
+#if __GLASGOW_HASKELL__ >= 707
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
+#endif
 module Data.Sized.Fin
     ( TNat
     , Fin
@@ -27,8 +30,12 @@ type TNat (a::Nat) = Sing a
 newtype Fin (n :: Nat) = Fin Integer
     deriving (Eq, Ord)
 
+#if __GLASGOW_HASKELL__ >= 707
+deriving instance Typeable Fin
+#else
 instance SingI nat => Typeable (Fin (nat :: Nat)) where
   typeOf _ = mkTyConApp (mkTyCon3 "sized-types" "Data.Sized.Fin" ("Fin#" ++ show (fromSing (sing :: Sing nat)))) []
+#endif
 
 fromNat :: Sing (n :: Nat) -> Integer
 fromNat = fromSing

--- a/Data/Sized/Sparse/Matrix.hs
+++ b/Data/Sized/Sparse/Matrix.hs
@@ -1,6 +1,6 @@
 -- | Sparse Matrix.
 --
--- Copyright: (c) 2009 University of Kansas
+-- Copyright: (c) 2009-2013 University of Kansas
 -- License: BSD3
 --
 -- Maintainer: Andy Gill <andygill@ku.edu>

--- a/Data/Sized/Unsigned.hs
+++ b/Data/Sized/Unsigned.hs
@@ -1,8 +1,11 @@
-{-# LANGUAGE ScopedTypeVariables, TypeFamilies, DataKinds, FlexibleContexts, DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables, TypeFamilies, CPP, FlexibleContexts, DataKinds #-}
+#if __GLASGOW_HASKELL__ >= 707
+{-# LANGUAGE StandaloneDeriving, DeriveDataTypeable #-}
+#endif
 
 -- | Unsigned, fixed sized numbers.
 --
--- Copyright: (c) 2009 University of Kansas
+-- Copyright: (c) 2009-2013 University of Kansas
 -- License: BSD3
 --
 -- Maintainer: Andy Gill <andygill@ku.edu>
@@ -105,8 +108,12 @@ showBits u = "0b" ++ reverse
                  | i <- [0..(bitSize u - 1)]
                  ]
 
+#if __GLASGOW_HASKELL__ >= 707
+deriving instance Typeable Unsigned
+#else
 instance SingI nat => Typeable (Unsigned (nat :: Nat)) where
   typeOf _ = mkTyConApp (mkTyCon3 "sized-types" "Data.Sized.Unsigned" ("Unsigned#" ++ show (fromSing (sing :: Sing nat)))) []
+#endif
 
 instance (SingI ix) => Bounded (Unsigned ix) where
 	minBound = Unsigned 0


### PR DESCRIPTION
should remain backwards-compatible
